### PR TITLE
Set cookie for the whole domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function login (opts) {
   }
 
   function encode (res, username) {
-    res.setHeader('Set-Cookie', cookie.serialize('gh_name', sign(username)))
+    res.setHeader('Set-Cookie', cookie.serialize('gh_name', sign(username)) + '; Path=/')
   }
 
   function sign (data) {


### PR DESCRIPTION
Currently sets cookie only for that specific redirect_uri
Ideally we want the cookie to persist through the whole site